### PR TITLE
Add  "Edit this page" link to website

### DIFF
--- a/book.json
+++ b/book.json
@@ -1,0 +1,10 @@
+{
+  "title": "Awesome Berlin",
+  "plugins": ["edit-link"],
+  "pluginsConfig": {
+    "edit-link": {
+      "base": "https://github.com/marlonbernardes/awesome-berlin/tree/master",
+      "label": "Edit this page"
+    }
+  }
+}


### PR DESCRIPTION
This PR adds a link to the header which will allow users to rapidly edit the current page:

![image](https://cloud.githubusercontent.com/assets/2975955/21313136/51542c1c-c5f0-11e6-809a-3bdcdcf89289.png)

