### PR TITLE
Landlord vs tenant

### DIFF
--- a/pt-br/pages/alugando-apartamento.md
+++ b/pt-br/pages/alugando-apartamento.md
@@ -13,7 +13,7 @@ mensal, como extrato bancário de vários meses;
 - *[SCHUFA](/pages/obtendo-schufa)* (documento que prova que você é um bom pagador)
 - *[Amtliche Meldebestätigung für die Anmeldung](/pages/registro-de-residencia.md)* (Confirmação oficial do registro de
 residência)
-- Alguns locatários exigem o visto de residência ou um termo de comprometimendo que você irá fazer um seguro
+- Alguns locatários exigem o visto de residência ou um termo de comprometimento que você irá fazer um seguro
 contra acidentes domésticos,
 
 <small>_1_- Se você não tem um documento alemão do último locatário, tente utilizar uma certidão negativa de livre de débitos
@@ -22,14 +22,14 @@ contra acidentes domésticos,
 ## Antes de começar a procura
 
  - Antes de tudo, **cuidado!** Nunca transfira dinheiro para um possível locador antes de assinar o contrato de aluguel. Muitas pessoas são vítimas de golpes por acreditarem em histórias (muitas vezes convincentes) e transferirem dinheiro para pessoas mal intencionadas. Este tipo de golpe é comum por aqui, então fique atento(a)!
- - Ao procurar por um apartamento, você poderá se deparar com os termos *Kaltmiete* e *Warmmiete*, e é importante entender a diferença para que você saiba qual valor você irá pagar por mês. O termo  *Kaltmiete* indica o valor frio do aluguel, ou seja: o valor a ser pago representa apenas os custos do aluguel e não inclui custos adicionais, como aquecimento, limpeza das áreas comuns, etc. O termo *Warmmiete* representa o aluguel "quente", que inclui os gastos adicionais, como aquecimento e água. Eletricidade e internet nem sempre fazem parte do *Warmmiete*, então leia a descrição do que está incluso antes de aluguar. Caso o valor do aluguel apresentado seja o frio (também chamado de *KM*), preveja cerca de 20% de custos adicionais para ter uma ideia do valor final.
- - Alugueis de longo prazo geralmente requerem que você faça um depósito de segurança (caução) após a assinatura do contrato (*Kaution* em alemão), que geralmente corresponde a 3x o valor do aluguel "frio" do apartamento (e geralmente pode ser parcelado em 3x). Este valor pode retornar para você após o término do contrato.
+ - Ao procurar por um apartamento, você poderá se deparar com os termos *Kaltmiete* e *Warmmiete*, e é importante entender a diferença para que você saiba qual valor você irá pagar por mês. O termo  *Kaltmiete* indica o valor frio do aluguel, ou seja: o valor a ser pago representa apenas os custos do aluguel e não inclui custos adicionais, como aquecimento, limpeza das áreas comuns, etc. O termo *Warmmiete* representa o aluguel "quente", que inclui os gastos adicionais, como aquecimento e água. Eletricidade e internet nem sempre fazem parte do *Warmmiete*, então leia a descrição do que está incluso antes de alugar. Caso o valor do aluguel apresentado seja o frio (também chamado de *KM*), preveja cerca de 20% de custos adicionais para ter uma ideia do valor final.
+ - Aluguéis de longo prazo geralmente requerem que você faça um depósito de segurança (caução) após a assinatura do contrato (*Kaution* em alemão), que geralmente corresponde a 3x o valor do aluguel "frio" do apartamento (e geralmente pode ser parcelado em 3x). Este valor pode retornar para você após o término do contrato.
  - O termo **Zimmer** representa a quantidade de cômodos da casa/apartamento. Cozinha, banheiros e sacadas não fazem parte do valor representado por este número. Como exemplo, um apartamento com 3 zimmer provavelmente possui 2 quartos de dormir e 1 sala de estar.
  - Algumas perguntas que podem te ajudar a filtrar a escolha de um apartamento:
   - Ele já vem mobiliado ou com cozinha montada?
   - Animais de estimação são permitidos?
   - Você conhece e gosta do bairro?
-  - Há garagem para bicicletas/carros e/ou aréa para guardar objetos? (*Keller*);
+  - Há garagem para bicicletas/carros e/ou área para guardar objetos? (*Keller*);
   - O aquecimento é a gás, elétrico, óleo ou carvão? (aquecedores elétricos geralmente são menos eficientes)
   - Qual a eficiência energética do apartamento? (geralmente esta informação é exibida em uma das fotos do apartamento)
   - Há caução? Qual o valor? (geralmente é 3x o "aluguel frio")
@@ -38,16 +38,13 @@ contra acidentes domésticos,
 
 ## Onde procurar
 
-O maior site de procura é o [ImmobilienScout24](https://www.immobilienscout24.de). Apesar de estar disponível apenas em alemão, se você usar o Google Translate, 
-não deverá encontrar grandes problemas para navegar. Você pode buscar por área, quantidade de 
-cômodos *(Zimmer)* e pelo preço. Outra funcionalidade interessante é que, quando se está logado, é possível visualizar a
-média de euros/m2 em comparação a imóveis semelhantes na mesma área.
+O maior site de procura é o [ImmobilienScout24](https://www.immobilienscout24.de). Apesar de estar disponível apenas em alemão, se você usar o Google Translate, não deverá encontrar grandes problemas para navegar. Você pode buscar por área, quantidade de cômodos *(Zimmer)* e pelo preço. Outra funcionalidade interessante é que, quando se está logado, é possível visualizar a média de euros/m2 em comparação a imóveis semelhantes na mesma área.
 
 Pelo próprio site você pode mandar seu interesse ao locador e esperar sua resposta (geralmente já com a data de visita).
 Use o template abaixo para mandar sua mensagem de interesse para visitar o apartamento:<sup>1</sup>
 <pre>
 Sehr geehrte(r) Frau/Herr ${SOBRENOME_DO_LOCATARIO},
-ich habe Ihre Anzeige gelesen und interessiere mich sehr für die Wohnung in. Ich würde mich sehr über einen Besichtigungstermin freuen. Ich bin jederzeit verfügbar. Sie können mich jederzeit per Email erreichen (${SEU_EMAIL}). Ich freue mich auf Ihre Antwort und wünsche Ihnen noch eine schöne Woche. 
+ich habe Ihre Anzeige gelesen und interessiere mich sehr für die Wohnung in. Ich würde mich sehr über einen Besichtigungstermin freuen. Ich bin jederzeit verfügbar. Sie können mich jederzeit per Email erreichen (${SEU_EMAIL}). Ich freue mich auf Ihre Antwort und wünsche Ihnen noch eine schöne Woche.
 Mit freundlichen Grüßen,
 ${SEU_NOME_COMPLETO}
 </pre>
@@ -70,23 +67,13 @@ tome cuidado ao substituir!</sub>
 ## O processo
 
 - As visitas em casas/apartamentos costumam ser acompanhadas do proprietário/agente imobiliário e normalmente todos os interessados pelo imóvel estão presentes ao mesmo tempo. Caso, após a visita, você tenha interesse em aplicar, você deve:
-  - Preencher o formulário de aplicação (Bewerbungsbogen) e enviar todos os documentos exigidos pelo seu
-locador/agente imobiliário (geralmente estão descritos no formulário) em PDF, por email. Você pode unir todos os documentos solicitados (respeitando a ordem) em um único PDF e enviar para o email do agente imobiliário. Algumas pessoas preenchem o formulário com antecedência e já o entregam (pessoalmente) no dia da visita do imóvel.
+  - Preencher o formulário de aplicação (Bewerbungsbogen) e enviar todos os documentos exigidos pelo seu locador/agente imobiliário (geralmente estão descritos no formulário) em PDF, por email. Você pode unir todos os documentos solicitados (respeitando a ordem) em um único PDF e enviar para o email do agente imobiliário. Algumas pessoas preenchem o formulário com antecedência e já o entregam (pessoalmente) no dia da visita do imóvel.
 
 ## Aplicação bem sucedida
 Finalmente, após um locador aceitar sua aplicação de aluguel, você será convidado para assinar o contrato e para retirar as chaves do imóvel. Não se esqueça de fazer o registro de residência no novo endereço tão logo possível. Também será necessário criar uma conta caução em um banco (veja abaixo), aonde o depósito de segurança deverá ser solicitado.
 
 ### Conta Caução - Kautionskonto
-Na Alemanha existe uma lei que oficializa o processo de caução utilizando contas específicas para esse intuíto. Oficialmente
-o caução só pode ser utilizado para devidos reparos a danos ao apartamento causados pelo locatário. Esse dinheiro só poderá ser
-retirado, ao final do contrato, pelo locador, para esses devidos fins, e o dinheiro restante volta para você.
-A conta cauçāo garante que isso ocorra, pois é feito ligado a você, o locador e o contrato. Para criar essa conta, você
-deve ter os dados do locador e o contrato em mãos, e enviá-los/exibi-los ao gerente de seu banco.
-Existe a opção de transferência direta para o locador, mas assim você se expõe ao risco de não reaver esse dinheiro. Para
-evitar dores de cabeça, a kautionskonto é a melhor opção. Algumas imobiliárias abrem esta conta para você e colocam as informações da conta caução no contrato de aluguel.
+Na Alemanha existe uma lei que oficializa o processo de caução utilizando contas específicas para esse intuíto. Oficialmente o caução só pode ser utilizado para devidos reparos a danos ao apartamento causados pelo locatário. Esse dinheiro só poderá ser retirado, ao final do contrato, pelo locador, para esses devidos fins, e o dinheiro restante volta para você. A conta cauçāo garante que isso ocorra, pois é feito ligado a você, o locador e o contrato. Para criar essa conta, você deve ter os dados do locador e o contrato em mãos, e enviá-los/exibi-los ao gerente de seu banco. Existe a opção de transferência direta para o locador, mas assim você se expõe ao risco de não reaver esse dinheiro. Para evitar dores de cabeça, a kautionskonto é a melhor opção. Algumas imobiliárias abrem esta conta para você e colocam as informações da conta caução no contrato de aluguel.
 
 ### Entrega das chaves
-Na entrega das chaves, verifique todo o apartamento, como equipamentos e danos já existentes. Todos esses aspectos devem 
-ser incluídos no contrato. Esses detalhes serão verificados ao final do contrato e houver algum dano ou equipamento faltante 
-(que não esteja descrito no contrato), o valor do reparo/compra será retirado diretamente da conta caução e você receberá um valor 
-menor ao reaver seu dinheiro.
+Na entrega das chaves, verifique todo o apartamento, como equipamentos e danos já existentes. Todos esses aspectos devem ser incluídos no contrato. Esses detalhes serão verificados ao final do contrato e houver algum dano ou equipamento faltante (que não esteja descrito no contrato), o valor do reparo/compra será retirado diretamente da conta caução e você receberá um valor menor ao reaver seu dinheiro.

--- a/pt-br/pages/alugando-apartamento.md
+++ b/pt-br/pages/alugando-apartamento.md
@@ -2,22 +2,18 @@
 
 ## Pré-requisitos
 
-Existem alguns documentos necessários para fazer uma aplicação válida de um apartamento. Antes de fazer qualquer
-aplicação, tenha em mãos:
+Existem alguns documentos necessários para fazer uma aplicação válida de um apartamento. Antes de fazer qualquer aplicação, tenha em mãos:
 
 - *Bewerbungsbogen* - formulário de aplicação, o locador lhe fornecerá esse documento (algumas imobiliárias mandam por este documento por email, após você agendar uma visita)
-- Últimos 3 contra cheques **ou** contrato de trabalho que prove sua renda mensal **ou** algo que comprove renda fixa
-mensal, como extrato bancário de vários meses;
+- Últimos 3 contra cheques **ou** contrato de trabalho que prove sua renda mensal **ou** algo que comprove renda fixa mensal, como extrato bancário de vários meses;
 - *Mietschuldenfreiheitsbescheinigung*<sup>1</sup>(Documento que prova que você não tem débitos com o último locador);
 - Documento de Identificação, ID ou passaporte + visto;
 - *[SCHUFA](/pages/obtendo-schufa)* (documento que prova que você é um bom pagador)
 - *[Amtliche Meldebestätigung für die Anmeldung](/pages/registro-de-residencia.md)* (Confirmação oficial do registro de
 residência)
-- Alguns locadores exigem o visto de residência ou um termo de comprometimento que você irá fazer um seguro
-contra acidentes domésticos,
+- Alguns locadores exigem o visto de residência ou um termo de comprometimento que você irá fazer um seguro contra acidentes domésticos,
 
-<small>_1_- Se você não tem um documento alemão do último locador, tente utilizar uma certidão negativa de livre de débitos
-(com tradução), ou explicar a situação, que devido a recente chegada é o seu primeiro aluguel na Alemanha.</small>
+<small>_1_- Se você não tem um documento alemão do último locador, tente utilizar uma certidão negativa de livre de débitos (com tradução), ou explicar a situação, que devido a recente chegada é o seu primeiro aluguel na Alemanha.</small>
 
 ## Antes de começar a procura
 
@@ -61,8 +57,7 @@ Há também outros sites para você procurar sua nova moradia. Os mais populares
 - http://www.lieblingsmieter.de/
 - https://www.immowelt.de/
 
-<sub>**1** - Note que para nomes masculinos se usa **Sehr geehrter Herr ...**, enquanto para nomes femininos se usa **Sehr geehrte Frau ...**,
-tome cuidado ao substituir!</sub>
+<sub>**1** - Note que para nomes masculinos se usa **Sehr geehrter Herr ...**, enquanto para nomes femininos se usa **Sehr geehrte Frau ...**, tome cuidado ao substituir!</sub>
 
 ## O processo
 

--- a/pt-br/pages/alugando-apartamento.md
+++ b/pt-br/pages/alugando-apartamento.md
@@ -13,10 +13,10 @@ mensal, como extrato bancário de vários meses;
 - *[SCHUFA](/pages/obtendo-schufa)* (documento que prova que você é um bom pagador)
 - *[Amtliche Meldebestätigung für die Anmeldung](/pages/registro-de-residencia.md)* (Confirmação oficial do registro de
 residência)
-- Alguns locatários exigem o visto de residência ou um termo de comprometimento que você irá fazer um seguro
+- Alguns locadores exigem o visto de residência ou um termo de comprometimento que você irá fazer um seguro
 contra acidentes domésticos,
 
-<small>_1_- Se você não tem um documento alemão do último locatário, tente utilizar uma certidão negativa de livre de débitos
+<small>_1_- Se você não tem um documento alemão do último locador, tente utilizar uma certidão negativa de livre de débitos
 (com tradução), ou explicar a situação, que devido a recente chegada é o seu primeiro aluguel na Alemanha.</small>
 
 ## Antes de começar a procura

--- a/pt-br/pages/obtendo-schufa.md
+++ b/pt-br/pages/obtendo-schufa.md
@@ -1,9 +1,9 @@
 # Obtendo a SCHUFA
 
 ## O que é a SCHUFA?
-A SCHUFA, Schutzgemeinschaft für allgemeine Kreditsicherung *(Associação de protecção ao crédito geral, trdução livre)*, funciona como uma certidão de bom "pagador".
+A SCHUFA, Schutzgemeinschaft für allgemeine Kreditsicherung *(Associação de protecção ao crédito geral, tradução livre)*, funciona como uma certidão de bom "pagador".
 
-Podemos compará-lo a orgãos no Brasil como, SPC e SERASA, porém utilizado para fins mais genéricos.
+Podemos compará-lo a órgãos no Brasil como, SPC e SERASA, porém utilizado para fins mais genéricos.
 Enquanto SPC e SERASA são usados para proteção de credores, aqui a SCHUFA é usada até para fechar contratos de aluguel de apartamentos.
 Aí que entra a necessidade de você ter a SCHUFA para alugar um apartamento em Berlin. Não é obrigatório, mas sem ela suas chances de alugar
 qualquer apartamento são quase nulas.
@@ -15,8 +15,7 @@ qualquer apartamento são quase nulas.
 ## Opçōes para obter a SCHUFA
 
 ### Internet
-Essa é a maneira mais prática de obter esse relatorio. O **Immobilien Scout 24** tem parceria com a SHCUFA, e basta preencher seus dados no formulário
-e enviar. Em alguns dias, sua SCHUFA chegará pelo correio. [Acesse o formulário aqui](https://bonitaetscheck.immobilienscout24.de/).
+Essa é a maneira mais prática de obter esse relatório. O **Immobilien Scout 24** tem parceria com a SCHUFA, e basta preencher seus dados no formulário e enviar. Em alguns dias, sua SCHUFA chegará pelo correio. [Acesse o formulário aqui](https://bonitaetscheck.immobilienscout24.de/).
 
 ### Post Bank
 Pra quem é old school e prefere ir presencialmente, existe a opção de requerir no Post Bank. Apenas alguns provem esse servico,

--- a/pt-br/pages/registro-de-residencia.md
+++ b/pt-br/pages/registro-de-residencia.md
@@ -16,10 +16,10 @@ O registro de residência (chamado de Anmeldung) é uma das etapas mais importan
 Abaixo um exemplo de formulário preenchido seguido de explicações:
 ![anmeldungsformular (english)](https://cloud.githubusercontent.com/assets/2975955/16777113/9b445a1e-4868-11e6-8fc0-3abd4dc6251d.png)
 
-1. Data (formato `dd.mm.yy`) que indica desde quando você mora neste endereço.  
+1. Data (formato `dd.mm.yy`) que indica desde quando você mora neste endereço.
 1. Nome da rua, número da casa e andar (em caso de prédios)
   2. Exemplo 1 (quem mora em casa): Blabla Straße 10
-  3. Exemplo 2 (quem mora em apartamento): Foobar Straße 10, 3.0G - Re  
+  3. Exemplo 2 (quem mora em apartamento): Foobar Straße 10, 3.0G - Re
     4. 3.0G == andar, Re == Localização do apartamento no andar (Re (Rechts) é direita em alemão. Use Li para esquerda e Mi para centro))
 1. Postal code
 1. Endereço antigo (caso seja o primeiro registro na Alemanha, preencha com o endereço antigo no Brasil - esqueci de preencher no formulário de exemplo, mas você deve preencher)
@@ -58,6 +58,6 @@ Abaixo um exemplo de formulário preenchido seguido de explicações:
  - Há muitos funcionários que não sabem ou não querem falar inglês. Por isso, leve todos os documentos preenchidos para minimizar as perguntas e qualquer interação humana (considerando que você não fala alemão).
  - Perguntas que já me fizeram (em alemão):
     - É a sua primeira vez se registrando na Alemanha?
-    - O seu apartamento fica pra esquerda (links), direita (rechts) ou meio (mitte)? (perguntam isso pq na Alemanha geralmente os apartamentos não tem um número único, e acabam sendo identificados pelo número do andar + localização (esquerda, direita, frente ou frente + esquerda, etc)
+    - O seu apartamento fica pra esquerda (links), direita (rechts) ou meio (mitte)? (perguntam isso porque na Alemanha geralmente os apartamentos não tem um número único, e acabam sendo identificados pelo número do andar + localização (esquerda, direita, frente ou frente + esquerda, etc)
  - Caso você não consiga ser atendido sem agendamento, tente novamente em outro Bürgeramt (ou no dia seguinte). Lembre-se: este documento é importante e é geralmente muito mais rápido ir presencialmente do que esperar a próxima data disponível na internet.
  - Novamente, tenha **paciência**. Caso consiga um atendimento e esteja sendo mal atendido, não desista!

--- a/pt-br/pages/transporte-publico.md
+++ b/pt-br/pages/transporte-publico.md
@@ -36,7 +36,7 @@ Para fazer isso:
   1. Acesse https://www.abo-antrag.de/
   2. Clique em "Abonnement abschließen" para começar a inscrição.
   3. Siga os passos indicados pelo site (dica: google translate) e preencha os formulários. Ter uma conta bancária alemã é obrigatório.
-  4. Após receber o email de confirmação, você precisa aguardar alguns dias para que sua inscrição fique "ativa" e você receba o cartão em sua casa (você deve receber aproximadamente uma semana antes à data de início dsua validade).
+  4. Após receber o email de confirmação, você precisa aguardar alguns dias para que sua inscrição fique "ativa" e você receba o cartão em sua casa (você deve receber aproximadamente uma semana antes à data de início da validade).
 
 ![sbahn](https://cloud.githubusercontent.com/assets/2975955/21577255/c1620f34-cf54-11e6-9859-ebad96aca928.gif)
 
@@ -62,7 +62,7 @@ Após solicitar um cartão anual você já tem direito a usufruir ao preço redu
 - É possível levar mais uma pessoa após as 20:00h e durante todo o fim de semana com o ticket mensal.
 - Os "Metrotrams" (linhas do Trams geralmente conectadas a uma estação de U-Bahn) operam 24h por dia, todos os dias da semana.
 - O transporte público em Berlin funciona com base em um "Sistema de honra" (Honor System). Não há roletas/catracas/barreiras para entrar em um transporte público. É esperado que você tenha (ou compre) o ticket toda vez que entrar em um dos meios de transporte, apesar de raramente existir alguém para verificar se você realmente o possui. Eventualmente fiscais aparecem e pedem para ver o ticket de todos que estão no mesmo vagão/ônibus. Mesmo sabendo que as chances de ninguém te fiscalizar sejam grandes (e a multa de €60,00 não seja tão absurda), por favor **compre o ticket**. Sei que é óbvio (e um pouco chato dizer), mas prefiro reforçar: não encare isso como uma "oportunidade para economizar" - se você usa o transporte público, não dê o "jeitinho brasileiro" (aliás - espero que você tenha deixado isso no Brasil), e pague o ticket!
-- O transporte público é muito pontual. Atrasos são bastante raros, e estações de trams/metrôs/trens possuem sempre um painel indicando quando tempo falta para o transporte chegar. Nas paradas de ônibus há sempre um papel indicando os horários da linha em cada um dos dias da semana.
+- O transporte público é muito pontual. Atrasos são bastante raros, e estações de trams/metrôs/trens possuem sempre um painel indicando quanto tempo falta para o transporte chegar. Nas paradas de ônibus há sempre um papel indicando os horários da linha em cada um dos dias da semana.
 - Há aplicativos muito úteis que podem ajudar no transporte pela cidade. Caso você tenha um smartphone, procure por Offi, Citymapper na Play Store/Apple Store. O Google Maps também permite baixar os mapas da cidade para acesso offline (algo que foi muito útil para mim).
 - Você pode usar o app BVG FahrInfo Plus para [Android](https://play.google.com/store/apps/details?id=de.eos.uptrade.android.fahrinfo.berlin) ou [Apple](https://itunes.apple.com/de/app/bvg-fahrinfo-plus-berlin/id284971745?l=en&mt=8) para comprar tickets online.
 - Talvez seja óbvio, mas não custa deixar claro: os tickets de longa duração (diário/semanal/mensal/etc) não estão associados a um meio de transporte. Em outras palavras: o mesmo ticket te dá direito a utilizar Trams, U-Bahn, S-Bahn, Ônibus, etc de forma ilimitada (até a data de validade do ticket).

--- a/pt-br/pages/trazendo-pet-do-brasil.md
+++ b/pt-br/pages/trazendo-pet-do-brasil.md
@@ -46,7 +46,7 @@ A requisição deve ser preenchida pelo veterinário responsável pelo animal. C
 
 ![sorologia-material](https://cloud.githubusercontent.com/assets/3342195/23272920/554b05de-f9fd-11e6-852d-3111a46f984e.jpg)
 
-  1. Requisição da sorologia, dentro de um saco plastico.
+  1. Requisição da sorologia, dentro de um saco plástico.
   2. Soro sanguíneo, enrolado em papel e colado na parede da caixa, para não ficar rolando dentro da caixa durante o transporte.
   3. Duas caixinhas de gelo reciclável.
 
@@ -112,16 +112,16 @@ check-in, e outro para entregar às autoridades europeias;
 portanto importante ficar com uma cópia dele.
 
 ## Desembarque e inspeção
-Grande parte das pessoas apenas passam com o animal pela fiscalização da fronteira e ninguém verifica se a documentação do animal está ok. Porém, o correto é que você procure o local onde o animal deve ser inspecionado. Se você não for atrás disso, ninguém vai ir te procurar para verificar a documentaçao.
+Grande parte das pessoas apenas passam com o animal pela fiscalização da fronteira e ninguém verifica se a documentação do animal está ok. Porém, o correto é que você procure o local onde o animal deve ser inspecionado. Se você não for atrás disso, ninguém vai ir te procurar para verificar a documentação.
 
 Essa inspeção deve ser feita no primeiro país que você entrar na União Européia. Se você tem alguma escala dentro da União Européia, o primeiro país que você entrou na UE é onde a inspeção deve ser feita.
 
-Em cada aeroporto, o local onde o animal é inspecionado é diferente. Por exemplo, no aeroporto de Lisboa em Portugal, a sala do veterinário fica logo ao lado da esteira onde se retira as bagagens. Normalmnete você encontra cartazes na parede com informacoes de como proceder.
+Em cada aeroporto, o local onde o animal é inspecionado é diferente. Por exemplo, no aeroporto de Lisboa em Portugal, a sala do veterinário fica logo ao lado da esteira onde se retira as bagagens. Normalmente você encontra cartazes na parede com informações de como proceder.
 
-ATENÇÃO: Em alguns países (por exemplo, Portugal), você precisa agendar essa inspeção. [Clicando aqui](https://ec.europa.eu/food/animals/pet-movement/eu-legislation/non-commercial-non-eu/tpe_en), você encontra o contato de todos os *Travellers Point of Entry* da UE. Na maioria dos países você pode fazer o agendamento por email, e não esqueca de incluir o número do voo que o animal vai chegar.
+ATENÇÃO: Em alguns países (por exemplo, Portugal), você precisa agendar essa inspeção. [Clicando aqui](https://ec.europa.eu/food/animals/pet-movement/eu-legislation/non-commercial-non-eu/tpe_en), você encontra o contato de todos os *Travellers Point of Entry* da UE. Na maioria dos países você pode fazer o agendamento por email, e não esqueça de incluir o número do voo que o animal vai chegar.
 Aproveite e se informe sobre o valor dessa inspeçāo. O valor varia em cada país (alguns não cobram nada), mas só para dar uma noção de valor, em Portugal custa 30 euros e na Alemanha 70 euros e normalmente só aceitam pagamento em dinheiro. Mas se informe, pois os valores podem ter mudado!
 
-Depois que o veterinário fizer a inspeção, ele vai assinar o CZI, e você deve sair da área de desembarque pela saída da Aduana/Alfândega em que você vai declarar o que está trazendo, e eles irão conferir se o veterinario assinou o CZI. Muitas pessoas costumam passar pela saída 'Nada a declarar', e não da nenhum problema, porém o correto seria passar pela Aduana/Alfândega declarando a entrada do animal.
+Depois que o veterinário fizer a inspeção, ele vai assinar o CZI, e você deve sair da área de desembarque pela saída da Aduana/Alfândega em que você vai declarar o que está trazendo, e eles irão conferir se o veterinário assinou o CZI. Muitas pessoas costumam passar pela saída 'Nada a declarar', e não da nenhum problema, porém o correto seria passar pela Aduana/Alfândega declarando a entrada do animal.
 
 ## Registro do animal em Berlin (Hundesteuer-Anmeldung)
 


### PR DESCRIPTION
- Landlord is wrongly being referenced as tenant in two phrases.

This branch was based on the `pedrovitti:fix-typo` branch that is not merged yet. It might be a good idea to merge `pedrovitti:fix-typo` branch before reviewing and merging this one (or use this diff https://github.com/pedrovitti/awesome-berlin/compare/fix-typo...pedrovitti:landlord-vs-tenant to review)