### PR TITLE
Add Mastodon alternative to social networks

### DIFF
--- a/en/pages/social-networks.md
+++ b/en/pages/social-networks.md
@@ -9,3 +9,4 @@ communities:
 - [Facebook - Free Advice Berlin](https://www.facebook.com/groups/FreeAdviceBerlin/)
 - [Reddit - /r/Berlin](https://www.reddit.com/r/berlin/)
 - [Forum - Toytown Germany](https://www.toytowngermany.com/forum/)
+- [Mastodon instance for Berlin](https://toot.berlin/)


### PR DESCRIPTION
Adding a Berlin focused Mastodon instance as an alternative for people who don't want to use Facebook or Twitter. See https://joinmastodon.org