### PR TITLE
Fixing berlin.de website protocol

### DIFF
--- a/en/pages/address-registration.md
+++ b/en/pages/address-registration.md
@@ -8,7 +8,7 @@ The document received immediately after your registration is really important, a
 
 - Passport (or Passports, in case more than one person are being registered in the same address)
 - Rental agreement (*Mietvertrag* or *Einzugsbestätigung des Wohnungsgebers*)
-- Registration form filled out (Anmeldungsformular). 
+- Registration form filled out (Anmeldungsformular).
   - [Registration form - English](https://github.com/marlonbernardes/awesome-berlin/raw/master/files/anmeldung_en.pdf)
   - [Registration form - German](https://github.com/marlonbernardes/awesome-berlin/raw/master/files/anmeldung_de.pdf)
 - If you are married, bring your marriage certificate (written in English or German)
@@ -43,7 +43,7 @@ Below you will find an example, followed by some explanations.
 
 ## How the registration works
 
-- Gather all the required documentation (passport(s), filled out registration form, confirmation of residence from your landlord (Template can be found [here](http://www.berlin.de/formularserver/formular.php?402544)), rental contract, marriage/birth certificate (if you are married/have children)
+- Gather all the required documentation (passport(s), filled out registration form, confirmation of residence from your landlord (Template can be found [here](https://www.berlin.de/formularserver/formular.php?402544)), rental contract, marriage/birth certificate (if you are married/have children)
 - Take your paperwork to a local registration office (*Bürgeramt*), but before that decide your strategy:
 
  **1) Make an online appointment (via [https://service.berlin.de/](https://service.berlin.de/))**

--- a/en/pages/obtaining-a-drivers-license.md
+++ b/en/pages/obtaining-a-drivers-license.md
@@ -25,7 +25,7 @@ You will be taking a digital test, probably in a tablet.
 
 When you sign up for a driving school (Fahrschule), you will almost certainly be given access to a smartphone app that will allow you to study the required 1000 questions. The questions will
 appear identically (or near-identically) to the way they will appear on the theorie test. There may be minor differences depending on the app you are using to study.
- 
+
 The theorie questions are updated every three months so it's best to study fast so you don't have to learn new questions.
 
 ## Translation of your current drivers license
@@ -33,7 +33,7 @@ Depending on where your current drivers license was issued, you may have to get 
 
 | Location          | Approx. Cost | Waiting Period | Other Information
 | ------------- |------------- |------------- |------------- |
-| [ADAC](https://www.adac.de/adac_vor_ort/berlin_brandenburg/verkehr_und_technik/fuehrerscheinfragen/default.aspx?ComponentId=67578&SourcePageId=61898) | €35 | approx. 10 days **(ADAC will keep your drivers license during this time)** | If you pick up the license for someone else, you will need their passport 
+| [ADAC](https://www.adac.de/adac_vor_ort/berlin_brandenburg/verkehr_und_technik/fuehrerscheinfragen/default.aspx?ComponentId=67578&SourcePageId=61898) | €35 | approx. 10 days **(ADAC will keep your drivers license during this time)** | If you pick up the license for someone else, you will need their passport
 
 ## Prior to submitting your application at the Bürgeramt:
 You need to complete the following tasks before going to the Bürgeramt. Note that the links below are a mere sampling and do not constitute an endorsement.
@@ -97,10 +97,10 @@ You will almost certainly have to surrender your current drivers license so be p
 ### Berlin.de (German language)
 - [Bürgeramt Locations](https://service.berlin.de/buergerberatung-aemter/)
 - Umschreibung einer ausländischen Fahrerlaubnis / Transfer of a foreign license:
-  - [aus EU-/EWR-Staat / from EU/EWR state](http://www.berlin.de/labo/mobilitaet/fahrerlaubnisse-personen-und-gueterbefoerderung/dienstleistungen/service.213924.php/dienstleistung/121598/)
-  - [aus nicht-EU-/EWR-Staat / from non-EU/EWR state](http://www.berlin.de/labo/mobilitaet/fahrerlaubnisse-personen-und-gueterbefoerderung/dienstleistungen/service.213924.php/dienstleistung/327537/)
+  - [aus EU-/EWR-Staat / from EU/EWR state](https://www.berlin.de/labo/mobilitaet/fahrerlaubnisse-personen-und-gueterbefoerderung/dienstleistungen/service.213924.php/dienstleistung/121598/)
+  - [aus nicht-EU-/EWR-Staat / from non-EU/EWR state](https://www.berlin.de/labo/mobilitaet/fahrerlaubnisse-personen-und-gueterbefoerderung/dienstleistungen/service.213924.php/dienstleistung/327537/)
 - [Fahrerlaubnis / Driving license](https://www.berlin.de/labo/mobilitaet/fahrerlaubnisse-personen-und-gueterbefoerderung/fahrerlaubnis-fuehrerschein/)
-- [More about changing a drivers license](http://www.berlin.de/labo/mobilitaet/fahrerlaubnisse-personen-und-gueterbefoerderung/fahrerlaubnis-fuehrerschein/artikel.232531.php)
+- [More about changing a drivers license](https://www.berlin.de/labo/mobilitaet/fahrerlaubnisse-personen-und-gueterbefoerderung/fahrerlaubnis-fuehrerschein/artikel.232531.php)
 - [Sample Photograph (Downloadable PDF)](https://www.berlin.de/labo/_assets/kraftfahrzeugwesen/foto-mustertafel.pdf)
 - [Bürgeramt location in Mitte](https://service.berlin.de/standort/123202/)
 

--- a/kr/pages/address-registration.md
+++ b/kr/pages/address-registration.md
@@ -44,7 +44,7 @@
 
 ## 전입신고 진행과정
 
-- 필요한 온갖 서류를 다 모아옵니다 (여권, 전입신고 신청서, 집주인한테 받은 허가증(대강 이렇게 생겼습니다 [링크](http://www.berlin.de/formularserver/formular.php?402544)), 계약서, 결혼증명서나 출생증명서
+- 필요한 온갖 서류를 다 모아옵니다 (여권, 전입신고 신청서, 집주인한테 받은 허가증(대강 이렇게 생겼습니다 [링크](https://www.berlin.de/formularserver/formular.php?402544)), 계약서, 결혼증명서나 출생증명서
 - 전입신고 센터 (*Bürgeramt*)에 가서 등록하기 전, 아래와 같은 사실을 유념하세요 :
 
  **1) 온라인으로 예약을 하고 가기 (주소 : [https://service.berlin.de/](https://service.berlin.de/))**

--- a/kr/pages/obtaining-a-drivers-license.md
+++ b/kr/pages/obtaining-a-drivers-license.md
@@ -23,7 +23,7 @@ There are two tests you will have to take (depending on your current drivers lic
 태블릿으로 보는 디지털 형식 시험을 보게 될 겁니다.
 
 운전면허학원 (Fahrschule)에 등록시, 필요한 문제은항 1000개에 접근할 수 있는 앱이 담긴 스마트폰을 받게 되실 건데요, 거의 비슷하게 실제 이론시험에 출제됩니다. 약간 앱별로 차이가 있을 수는 있습니다만 거의 비슷하게 출제됩니다.
- 
+
 이론시험 문제는 매 3달마다 바뀌므로 최대한 빨리 시험에 응시하는 것이 새 문제를 외우는 것보다 훨씬 이득입니다.
 
 ## 보유중인 면허증 번역
@@ -91,10 +91,10 @@ Bürgeramt에 가기 전 아래 서류들을 준비하세요. 아래는 단순�
 ### Berlin.de (German language)
 - [Bürgeramt Locations](https://service.berlin.de/buergerberatung-aemter/)
 - Umschreibung einer ausländischen Fahrerlaubnis / Transfer of a foreign license:
-  - [aus EU-/EWR-Staat / from EU/EWR state](http://www.berlin.de/labo/mobilitaet/fahrerlaubnisse-personen-und-gueterbefoerderung/dienstleistungen/service.213924.php/dienstleistung/121598/)
-  - [aus nicht-EU-/EWR-Staat / from non-EU/EWR state](http://www.berlin.de/labo/mobilitaet/fahrerlaubnisse-personen-und-gueterbefoerderung/dienstleistungen/service.213924.php/dienstleistung/327537/)
+  - [aus EU-/EWR-Staat / from EU/EWR state](https://www.berlin.de/labo/mobilitaet/fahrerlaubnisse-personen-und-gueterbefoerderung/dienstleistungen/service.213924.php/dienstleistung/121598/)
+  - [aus nicht-EU-/EWR-Staat / from non-EU/EWR state](https://www.berlin.de/labo/mobilitaet/fahrerlaubnisse-personen-und-gueterbefoerderung/dienstleistungen/service.213924.php/dienstleistung/327537/)
 - [Fahrerlaubnis / Driving license](https://www.berlin.de/labo/mobilitaet/fahrerlaubnisse-personen-und-gueterbefoerderung/fahrerlaubnis-fuehrerschein/)
-- [More about changing a drivers license](http://www.berlin.de/labo/mobilitaet/fahrerlaubnisse-personen-und-gueterbefoerderung/fahrerlaubnis-fuehrerschein/artikel.232531.php)
+- [More about changing a drivers license](https://www.berlin.de/labo/mobilitaet/fahrerlaubnisse-personen-und-gueterbefoerderung/fahrerlaubnis-fuehrerschein/artikel.232531.php)
 - [Sample Photograph (Downloadable PDF)](https://www.berlin.de/labo/_assets/kraftfahrzeugwesen/foto-mustertafel.pdf)
 - [Bürgeramt location in Mitte](https://service.berlin.de/standort/123202/)
 

--- a/pt-br/pages/obtendo-a-carteira-de-motorista.md
+++ b/pt-br/pages/obtendo-a-carteira-de-motorista.md
@@ -80,10 +80,10 @@ Você deve completar os seguintes passos antes de ir ao Bürgeramt. Note que as 
 ### Berlin.de (German language)
 - [Localizações de Bürgeramts](https://service.berlin.de/buergerberatung-aemter/)
 - Umschreibung einer ausländischen Fahrerlaubnis / Trasferindo uma carteira estrangeira:
-  - [aus EU-/EWR-Staat / from EU/EWR state](http://www.berlin.de/labo/mobilitaet/fahrerlaubnisse-personen-und-gueterbefoerderung/dienstleistungen/service.213924.php/dienstleistung/121598/)
-  - [aus nicht-EU-/EWR-Staat / from non-EU/EWR state](http://www.berlin.de/labo/mobilitaet/fahrerlaubnisse-personen-und-gueterbefoerderung/dienstleistungen/service.213924.php/dienstleistung/327537/)
+  - [aus EU-/EWR-Staat / from EU/EWR state](https://www.berlin.de/labo/mobilitaet/fahrerlaubnisse-personen-und-gueterbefoerderung/dienstleistungen/service.213924.php/dienstleistung/121598/)
+  - [aus nicht-EU-/EWR-Staat / from non-EU/EWR state](https://www.berlin.de/labo/mobilitaet/fahrerlaubnisse-personen-und-gueterbefoerderung/dienstleistungen/service.213924.php/dienstleistung/327537/)
 - [Fahrerlaubnis / Carteira de motorista](https://www.berlin.de/labo/mobilitaet/fahrerlaubnisse-personen-und-gueterbefoerderung/fahrerlaubnis-fuehrerschein/)
-- [Mais sobre como transferir sua carteira de motorista](http://www.berlin.de/labo/mobilitaet/fahrerlaubnisse-personen-und-gueterbefoerderung/fahrerlaubnis-fuehrerschein/artikel.232531.php)
+- [Mais sobre como transferir sua carteira de motorista](https://www.berlin.de/labo/mobilitaet/fahrerlaubnisse-personen-und-gueterbefoerderung/fahrerlaubnis-fuehrerschein/artikel.232531.php)
 - [Exemplo de foto (PDF para download)](https://www.berlin.de/labo/_assets/kraftfahrzeugwesen/foto-mustertafel.pdf)
 - [Localizações de Bürgeramts no Mitte](https://service.berlin.de/standort/123202/)
 
@@ -94,4 +94,3 @@ Você deve completar os seguintes passos antes de ir ao Bürgeramt. Note que as 
 ### Wikipedia
 - [Sinais de trânsito alemães](https://en.wikipedia.org/wiki/Road_signs_in_Germany)
 - [Categorias das carteiras de motorista na Europa](https://en.wikipedia.org/wiki/European_driving_licence#Categories_valid_in_all_EEA_member_states)
-

--- a/pt-br/pages/trazendo-pet-do-brasil.md
+++ b/pt-br/pages/trazendo-pet-do-brasil.md
@@ -139,8 +139,8 @@ Depois que o veterinário fizer a inspeção, ele vai assinar o CZI, e você dev
 **Este registro deve ser feito apenas para cachorros.**
 
 É obrigatório fazer o registro do animal no Finanzamt e pagar o imposto de 120 euros por ano.
-[Clique aqui](http://www.berlin.de/sen/finanzen/steuern/downloads/artikel.9740.php) para baixar o formulário que deve ser entregue no dia do registro do animal.
-Você encontra esse formulário já impresso no Finanzamt, mas é sempre bom levar já preenchido (ainda mais se você não fala Alemão). 
+[Clique aqui](https://www.berlin.de/sen/finanzen/steuern/downloads/artikel.9740.php) para baixar o formulário que deve ser entregue no dia do registro do animal.
+Você encontra esse formulário já impresso no Finanzamt, mas é sempre bom levar já preenchido (ainda mais se você não fala Alemão).
 No dia que fizer o registro, você receberá a tag de identificação do animal que deve ser mantida na coleira.
 
 ## Mais informações


### PR DESCRIPTION
When you try to book an appointment using `http:`, it will always end up on an error page.