### PR TITLE
Adiciona Transferwise a lista de bancos, e atualiza dados sobro N26

### DIFF
--- a/en/pages/bank-account.md
+++ b/en/pages/bank-account.md
@@ -41,7 +41,7 @@ ING-DiBa AG is a subsidiary of the Dutch multinational ING Group. It's also an o
 
 ### Transferwise Borderless Account
 This is the fastest and least bureaucratic option. All you need is a passport and an address to send the card to. In less than a week you will have a German debit card and a bank account. Transferwise's limits and fees are among the best in the industry (including for international transfers, outside Europe), but always worth it [CHECK OUT](https://transferwise.com/help/13/understanding-fees-and-rates)
-- Visit the [Transferwise](https://transferwise.com/invite/u/eduardoj98) website sign up and follow the onscreen steps.
+- Visit the [Transferwise](https://transferwise.com/register#/) website sign up and follow the onscreen steps.
 
 ### Other Options
 - [Revolut](https://www.revolut.com)

--- a/en/pages/bank-account.md
+++ b/en/pages/bank-account.md
@@ -32,13 +32,16 @@ Deutsche bank is the only physical bank that offers a large part of its services
 These banks are different from other banks, as there are no physical branches, so you can do everything online. Using such banks, one gets argubaly better technological benefits.
 
 ### [N26](https://n26.com)
-N26 is often recommended because you can open an account even before your Anmeldung. Opening a bank account here is usually fast and easy. You can sign up for an account [here](https://app.n26.com/register) and then follow the website instructions to create your bank account. You will also need a smartphone, a passport and a German address to activate your bank account.
+N26 is often recommended because you can open an account even before your Anmeldung (depending on where you are [from](https://support.n26.com/en-eu/getting-started/personal-information/how-to-prove-my-identity)). Opening a bank account here is usually fast and easy. You can sign up for an account [here](https://app.n26.com/register) and then follow the website instructions to create your bank account. You will also need a smartphone, a passport and a German address to activate your bank account.
 It offers 100% of its banking experience in English.
 
 ### [ING-DiBa](https://www.ing-diba.de/)
 
 ING-DiBa AG is a subsidiary of the Dutch multinational ING Group. It's also an online bank with no physical branches. Opening an account costs nothing but it may take from one to two weeks. The bank offers a Giro and Visa card with no yearly fees. You can use your VISA card to withdraw for free in any European country. If you have a partner they can also have extra cards for. Interested? Start [here](https://produkte.banking.ing-diba.de/pub/girokonto-einzelkonto).
 
+### Transferwise Borderless Account
+This is the fastest and least bureaucratic option. All you need is a passport and an address to send the card to. In less than a week you will have a German debit card and a bank account. Transferwise's limits and fees are among the best in the industry (including for international transfers, outside Europe), but always worth it [CHECK OUT](https://transferwise.com/help/13/understanding-fees-and-rates)
+- Visit the [Transferwise](https://transferwise.com/invite/u/eduardoj98) website sign up and follow the onscreen steps.
+
 ### Other Options
 - [Revolut](https://www.revolut.com)
-- [Transferwise](https://transferwise.com)

--- a/en/pages/renting-an-apartment.md
+++ b/en/pages/renting-an-apartment.md
@@ -60,6 +60,7 @@ There are other websites/real estate agencies for you to search. The following a
   - https://www.i-live-berlin.de/
   - https://www.immowelt.de/
   - https://www.nestpick.com/
+  - https://wunderflats.com/en/
 
 [2] - Note that for male names you must use “Sehr geehrter Herr” ..., while for female names, you must use Sehr geehrte Frau ….
 

--- a/kr/pages/bank-account.md
+++ b/kr/pages/bank-account.md
@@ -42,4 +42,4 @@ ING-DiBa AG 네덜란드 다국적 회사 ING그룹의 자회사고, 인터넷 �
  
 ### 다른 선택
 - [Revolut](https://www.revolut.com)
-- [Transferwise](https://transferwise.com)
+

--- a/kr/pages/bank-account.md
+++ b/kr/pages/bank-account.md
@@ -36,6 +36,10 @@ N26 은 가장 많이 추천받는데, 왜냐하면 지긋지긋한 거주등록
 
 ING-DiBa AG 네덜란드 다국적 회사 ING그룹의 자회사고, 인터넷 은행입니다. 지점이 없습니다. 계좌를 여는 데 돈이 들거나 하지 않지만 대강 계좌 개설에 1-2주는 걸립니다. 이 은행에서는 Giro랑 Visa카드를 연회비 없이 발급해줍니다. VISA카드로 어느 유럽 국가에서도 무료로 인출할 수 있습니다. 만약 배우자가 있다면 배우자용 카드도 발급해 줍니다. 참고 [링크](https://produkte.banking.ing-diba.de/pub/girokonto-einzelkonto).
 
+### [Transferwise](https://transferwise.com/de)
+이것은 가장 빠르고 가장 관료적 인 옵션입니다. 여권과 카드를 보낼 주소 만 있으면됩니다. 일주일 이내에 독일 직불 카드와 은행 계좌가 생깁니다. Transferwise의 한도 및 요금은 업계 최고 수준입니다 (유럽 이외의 국제 환승 포함).
+- [Transferwise](transferwise.com/invite/u/eduardoj98) 웹 사이트 (이메일 및 비밀번호)에 액세스하고 화면의 단계를 따릅니다.
+ 
 ### 다른 선택
 - [Revolut](https://www.revolut.com)
 - [Transferwise](https://transferwise.com)

--- a/kr/pages/bank-account.md
+++ b/kr/pages/bank-account.md
@@ -38,8 +38,7 @@ ING-DiBa AG 네덜란드 다국적 회사 ING그룹의 자회사고, 인터넷 �
 
 ### [Transferwise](https://transferwise.com/de)
 이것은 가장 빠르고 가장 관료적 인 옵션입니다. 여권과 카드를 보낼 주소 만 있으면됩니다. 일주일 이내에 독일 직불 카드와 은행 계좌가 생깁니다. Transferwise의 한도 및 요금은 업계 최고 수준입니다 (유럽 이외의 국제 환승 포함).
-- [Transferwise](transferwise.com/invite/u/eduardoj98) 웹 사이트 (이메일 및 비밀번호)에 액세스하고 화면의 단계를 따릅니다.
+- [Transferwise](https://transferwise.com/register#/) 웹 사이트 (이메일 및 비밀번호)에 액세스하고 화면의 단계를 따릅니다.
  
 ### 다른 선택
 - [Revolut](https://www.revolut.com)
-

--- a/kr/pages/renting-an-apartment.md
+++ b/kr/pages/renting-an-apartment.md
@@ -66,6 +66,7 @@ ${성을 포함한 이름}
   - https://www.i-live-berlin.de/
   - https://www.immowelt.de/
   - https://www.nestpick.com/
+  - https://wunderflats.com/
 
 [2] - 남자 이름에는 “Sehr geehrter Herr ….”를 사용해야 하고, 여자 이름의 경우 "Sehr geehrte Frau …."를 사용해야 합니다.
 

--- a/pt-br/pages/alugando-apartamento.md
+++ b/pt-br/pages/alugando-apartamento.md
@@ -59,6 +59,7 @@ Há também outros sites para você procurar sua nova moradia. Os mais populares
   - https://www.i-live-berlin.de/
   - https://www.immowelt.de/
   - https://www.nestpick.com/
+  - https://wunderflats.com/
 
 <sub>**1** - Note que para nomes masculinos se usa **Sehr geehrter Herr ...**, enquanto para nomes femininos se usa **Sehr geehrte Frau ...**, tome cuidado ao substituir!</sub>
 

--- a/pt-br/pages/conta-bancaria.md
+++ b/pt-br/pages/conta-bancaria.md
@@ -16,7 +16,12 @@ Clientes do DB podem realizar saques (sem custo) em caixas eletrônicos dos segu
 
 ## N26
 
-Abrir uma conta no N26 é relativamente fácil e rápido. Cadastre-se em [https://n26.com/](https://n26.com/) e siga os passos indicados. Será necessário enviar um scan de seu passaporte e parear seu smartphone com o aplicativo (um número de telefone da Alemanha é requerido). Após, será necessário verificar sua identidade para que sua conta fique ativa. Há duas formas de fazer essa verificação:
+Abrir uma conta no N26 é relativamente fácil e rápido. Cadastre-se em [https://n26.com/](https://n26.com/) e siga os passos indicados. Será necessário enviar um scan de seu passaporte, registro de residência e parear seu smartphone com o aplicativo (um número de telefone da Alemanha é requerido). Após, será necessário verificar sua identidade para que sua conta fique ativa. Há duas formas de fazer essa verificação:
 - via vídeo chamada (apenas siga os passos do aplicativo - será necessário mostrar seu passaporte pela webcam.) **Edit 19/11/2016:** N26 agora aceita passaporte Brasileiro para identificação via vídeo chamada! 
 - via PostIndent (você deverá imprimir um código de barras - recebido por email - e comparecer em um Post office com sua identidade e seu registro de residência. Não tem custo nenhum, mas leva entre 1 e 2 dias para o banco receber essa confirmação. Há vários Post offices espalhados pela cidade, o que eu fui fica em Frankfurt Allee 1)
 
+## Transferwise Borderless Account
+Esta é a opção mais rápida e menos burocrática. Tudo que você precisa é do passaporte e um endereço para te enviarem o cartão. 
+Em menos de uma semana você terá um cartão de débito alemão e uma conta bancária. 
+Os limites e tarifas da Transferwise estao entre as melhores do mercado (inclusive para transferencias internacionais, fora da europa), mas vale a pena [CONFERIR](https://transferwise.com/pt/help/13/entendendo-tarifas-e-cambios)
+- Acesse o site da [Transferwise](transferwise.com/invite/u/eduardoj98) faça cadastro (email e senha) e siga os passos na tela.

--- a/pt-br/pages/conta-bancaria.md
+++ b/pt-br/pages/conta-bancaria.md
@@ -24,4 +24,4 @@ Abrir uma conta no N26 é relativamente fácil e rápido. Cadastre-se em [https:
 Esta é a opção mais rápida e menos burocrática. Tudo que você precisa é do passaporte e um endereço para te enviarem o cartão. 
 Em menos de uma semana você terá um cartão de débito alemão e uma conta bancária. 
 Os limites e tarifas da Transferwise estao entre as melhores do mercado (inclusive para transferencias internacionais, fora da europa), mas vale a pena [CONFERIR](https://transferwise.com/pt/help/13/entendendo-tarifas-e-cambios)
-- Acesse o site da [Transferwise](transferwise.com/invite/u/eduardoj98) faça cadastro (email e senha) e siga os passos na tela.
+- Acesse o site da [Transferwise](https://transferwise.com/register#/) faça cadastro (email e senha) e siga os passos na tela.


### PR DESCRIPTION
A N26 mudou o processo de verificação de identidade de brasileiros, agora é necessário ter o resident permit.
Uma opção que funcionou para mim e para vários conhecidos foi abrir uma conta Transferwise Borderless account, a conta é super rápido e fácil de se abrir.